### PR TITLE
Show move ghosts and scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,35 +5,69 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>リバーシ</title>
   <style>
-    body { text-align: center; margin: 0; }
-    table { border-collapse: collapse; margin: auto; width: 100%; max-width: 320px; }
+    body {
+      text-align: center;
+      margin: 0;
+      font-family: "Arial", sans-serif;
+      background: #fef9e7;
+    }
+    h1 {
+      color: #3b7;
+    }
+    table {
+      border-collapse: collapse;
+      margin: auto;
+      width: 100%;
+      max-width: 320px;
+    }
     td {
-      width: 12.5vw; height: 12.5vw;
-      max-width: 40px; max-height: 40px;
+      width: 12.5vw;
+      height: 12.5vw;
+      max-width: 40px;
+      max-height: 40px;
       border: 1px solid black;
-      background: green;
+      background: #8fbc8f;
       position: relative;
       box-sizing: border-box;
     }
     .disk {
-      width: 80%; height: 80%;
+      width: 80%;
+      height: 80%;
       border-radius: 50%;
       position: absolute;
-      top: 10%; left: 10%;
+      top: 10%;
+      left: 10%;
     }
     .black { background: black; }
     .white { background: white; }
+    .ghost {
+      opacity: 0.4;
+    }
+    #score {
+      font-size: 1.2em;
+      margin: 0.5em 0;
+    }
+    button {
+      font-size: 1.1em;
+      padding: 0.5em 1em;
+      margin-top: 0.5em;
+      background: #f7c948;
+      border: none;
+      border-radius: 4px;
+    }
   </style>
 </head>
 <body>
   <h1>リバーシ（2人対戦）</h1>
   <div id="turn">黒の番です</div>
+  <div id="score"></div>
   <p>タップして石を置いてね</p>
   <table id="board"></table>
   <button id="reset">リセット</button>
 
   <script>
     const board = document.getElementById("board");
+    const scoreEl = document.getElementById("score");
     document.getElementById("reset").addEventListener("click", () => {
       board.innerHTML = "";
       init();
@@ -73,7 +107,19 @@
           }
         }
       }
-      document.getElementById("turn").textContent = current === BLACK ? "黒の番です" : "白の番です";
+
+      const valid = getValidMoves(current);
+      for (const [x, y] of valid) {
+        const cell = board.rows[y].cells[x];
+        const ghost = document.createElement("div");
+        ghost.className =
+          "disk ghost " + (current === BLACK ? "black" : "white");
+        cell.appendChild(ghost);
+      }
+
+      document.getElementById("turn").textContent =
+        current === BLACK ? "黒の番です" : "白の番です";
+      updateScore();
     }
 
     function handleClick(e) {
@@ -86,6 +132,27 @@
     }
 
     const dirs = [[1,0], [-1,0], [0,1], [0,-1], [1,1], [-1,-1], [1,-1], [-1,1]];
+
+    function getValidMoves(color) {
+      const moves = [];
+      for (let y = 0; y < size; y++) {
+        for (let x = 0; x < size; x++) {
+          if (canPut(x, y, color)) moves.push([x, y]);
+        }
+      }
+      return moves;
+    }
+
+    function updateScore() {
+      let b = 0, w = 0;
+      for (let y = 0; y < size; y++) {
+        for (let x = 0; x < size; x++) {
+          if (grid[y][x] === BLACK) b++;
+          else if (grid[y][x] === WHITE) w++;
+        }
+      }
+      scoreEl.textContent = `黒:${b} 白:${w}`;
+    }
 
     function canPut(x, y, color) {
       if (grid[y][x] !== EMPTY) return false;


### PR DESCRIPTION
## Summary
- style tweaks for a child-friendly UI
- show ghost pieces for valid moves
- display score for each color

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687f4b6486708323a018727420db0827