### PR TITLE
Fix board scaling and add turn skipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,24 +8,24 @@
     body {
       text-align: center;
       margin: 0;
-      font-family: "Arial", sans-serif;
-      background: #fef9e7;
+      font-family: system-ui, sans-serif;
+      background: #f4f4f4;
     }
     h1 {
-      color: #3b7;
+      color: #2c3e50;
+      margin-top: 0.5em;
     }
     table {
       border-collapse: collapse;
       margin: auto;
       width: 100%;
       max-width: 320px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
     }
     td {
-      width: 12.5vw;
-      height: 12.5vw;
-      max-width: 40px;
-      max-height: 40px;
-      border: 1px solid black;
+      width: calc(min(12.5vw, 40px));
+      aspect-ratio: 1 / 1;
+      border: 1px solid #333;
       background: #8fbc8f;
       position: relative;
       box-sizing: border-box;
@@ -37,9 +37,10 @@
       position: absolute;
       top: 10%;
       left: 10%;
+      box-shadow: inset 0 0 2px rgba(0,0,0,0.4);
     }
-    .black { background: black; }
-    .white { background: white; }
+    .black { background: #000; }
+    .white { background: #fff; }
     .ghost {
       opacity: 0.4;
     }
@@ -51,9 +52,20 @@
       font-size: 1.1em;
       padding: 0.5em 1em;
       margin-top: 0.5em;
-      background: #f7c948;
+      background: #4caf50;
+      color: #fff;
       border: none;
-      border-radius: 4px;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    button:hover {
+      background: #43a047;
+    }
+    #message {
+      color: #d33;
+      min-height: 1.2em;
+      margin: 0.5em;
     }
   </style>
 </head>
@@ -61,6 +73,7 @@
   <h1>リバーシ（2人対戦）</h1>
   <div id="turn">黒の番です</div>
   <div id="score"></div>
+  <div id="message"></div>
   <p>タップして石を置いてね</p>
   <table id="board"></table>
   <button id="reset">リセット</button>
@@ -68,6 +81,7 @@
   <script>
     const board = document.getElementById("board");
     const scoreEl = document.getElementById("score");
+    const messageEl = document.getElementById("message");
     document.getElementById("reset").addEventListener("click", () => {
       board.innerHTML = "";
       init();
@@ -128,6 +142,19 @@
       if (!canPut(x, y, current)) return;
       put(x, y, current);
       current = current === BLACK ? WHITE : BLACK;
+
+      if (getValidMoves(current).length === 0) {
+        const other = current === BLACK ? WHITE : BLACK;
+        if (getValidMoves(other).length === 0) {
+          showMessage('これ以上置ける場所がありません');
+          render();
+          return;
+        } else {
+          showMessage((current === BLACK ? '黒' : '白') + 'は置ける場所がありません。パスします');
+          current = other;
+        }
+      }
+
       render();
     }
 
@@ -143,16 +170,21 @@
       return moves;
     }
 
-    function updateScore() {
-      let b = 0, w = 0;
+  function updateScore() {
+    let b = 0, w = 0;
       for (let y = 0; y < size; y++) {
         for (let x = 0; x < size; x++) {
           if (grid[y][x] === BLACK) b++;
           else if (grid[y][x] === WHITE) w++;
         }
       }
-      scoreEl.textContent = `黒:${b} 白:${w}`;
-    }
+    scoreEl.textContent = `黒:${b} 白:${w}`;
+  }
+
+  function showMessage(msg) {
+    messageEl.textContent = msg;
+    setTimeout(() => { messageEl.textContent = ''; }, 1500);
+  }
 
     function canPut(x, y, color) {
       if (grid[y][x] !== EMPTY) return false;


### PR DESCRIPTION
## Summary
- refine styling for a modern look and square board cells
- show messages in a dedicated area
- skip a player's turn when no valid moves remain

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_687f4d31a7848323bcdaa432c6ecfe00