### PR TITLE
Fix board dimensions for smartphone

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,13 +18,13 @@
     table {
       border-collapse: collapse;
       margin: auto;
-      width: 100%;
-      max-width: 320px;
+      width: 320px;
+      height: 320px;
       box-shadow: 0 2px 6px rgba(0,0,0,0.2);
     }
     td {
-      width: calc(min(12.5vw, 40px));
-      aspect-ratio: 1 / 1;
+      width: 40px;
+      height: 40px;
       border: 1px solid #333;
       background: #8fbc8f;
       position: relative;


### PR DESCRIPTION
## Summary
- revert board layout to original 320px x 320px size
- ensure cells are 40px and board remains square

## Testing
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_687f4f8513bc8323aa4dea87d7baef4b